### PR TITLE
Add shrug response to bot responses

### DIFF
--- a/botResponses/botFunctions.js
+++ b/botResponses/botFunctions.js
@@ -54,7 +54,11 @@ var botFunctions = {
   code: {
     condition: /\/code/,
     response: responses.botResponseCode
-  }
+  },
+  shrug: {
+    condition: /\/shrug/,
+    response: responses.botResponseShrug,
+  },
   // chatWithBot: {
   //   condition: /bot\b|hello|hi/,
   //   response: responses.botResponseChat

--- a/botResponses/botResponses.js
+++ b/botResponses/botResponses.js
@@ -64,6 +64,10 @@ function botResponseHug({ room }) {
   chatHelpers.send(`⊂(´・ω・｀⊂)`, room)
 }
 
+function botResponseShrug({ room }) {
+  chatHelpers.send(String.raw`¯\\\_(ツ)_/¯`, room)
+}
+
 function botResponseHello({ room, data: { fromUser: { displayName: name } } }) {
   chatHelpers.send(`oh hi there ${name}`, room)
   respondWithGif('hi', room)
@@ -206,4 +210,5 @@ exports.botResponseWeatherInCity = botResponseWeatherInCity
 // exports.botResponseWindows = botResponseWindows
 exports.botResponseDontGiveUp = botResponseDontGiveUp
 exports.botResponseCode = botResponseCode
+exports.botResponseShrug = botResponseShrug
 // exports.botResponseChat = botResponseChat


### PR DESCRIPTION
I was able to work around the backslash escape issue by using [String.raw](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/raw). You can test and see that it displays as expected now. 👍 We will all be having SO MUCH fun with this now 😄

![](https://media.giphy.com/media/13Qumr2SLqrl5e/giphy.gif)