### PR TITLE
fixed '/code' bug by adding anchors to regex

### DIFF
--- a/botResponses/botFunctions.js
+++ b/botResponses/botFunctions.js
@@ -52,7 +52,7 @@ var botFunctions = {
     response: responses.botResponseWeatherInCity
   },
   code: {
-    condition: /\/code/,
+    condition: /^\/code\b/,
     response: responses.botResponseCode
   },
   shrug: {


### PR DESCRIPTION
Previously, regex would find any example of `/code` example( `http://codepen`). Adding anchors appears to solve this.