### PR TITLE
Disable '/windows' command

### DIFF
--- a/botResponses/botFunctions.js
+++ b/botResponses/botFunctions.js
@@ -35,10 +35,10 @@ var botFunctions = {
     condition: /\/hug/,
     response: responses.botResponseHug
   },
-  uselinux: {
-    condition: /\/windows/,
-    response: responses.botResponseUseLinux
-  },
+  // uselinux: {
+  //   condition: /\/windows/,
+  //   response: responses.botResponseUseLinux
+  // },
   motivate: {
     condition: /\/motivate/,
     response: responses.botResponseDontGiveUp

--- a/botResponses/botFunctions.js
+++ b/botResponses/botFunctions.js
@@ -35,10 +35,6 @@ var botFunctions = {
     condition: /\/hug/,
     response: responses.botResponseHug
   },
-  // uselinux: {
-  //   condition: /\/windows/,
-  //   response: responses.botResponseUseLinux
-  // },
   motivate: {
     condition: /\/motivate/,
     response: responses.botResponseDontGiveUp

--- a/botResponses/botResponses.js
+++ b/botResponses/botResponses.js
@@ -8,13 +8,13 @@ var helpers = require('../helpers/helpers.js')
 var chatHelpers = require('../helpers/chatHelpers.js')
 var { respondWithGif } = require('./giphy')
 
-function botResponseUseLinux({ room }) {
-  chatHelpers.send(
-    `[Why you shouldn't use Windows for TOP.](https://medium.com/@codyloyd/why-cant-i-use-windows-for-the-odin-project-bf20a4bb135f#.29b6s6fp5)
-     - [If you need to, check out Windows Subsystem for Linux](http://wsl-guide.org/)`,
-    room
-  )
-}
+// function botResponseUseLinux({ room }) {
+//   chatHelpers.send(
+//     `[Why you shouldn't use Windows for TOP.](https://medium.com/@codyloyd/why-cant-i-use-windows-for-the-odin-project-bf20a4bb135f#.29b6s6fp5)
+//      - [If you need to, check out Windows Subsystem for Linux](http://wsl-guide.org/)`,
+//     room
+//   )
+// }
 
 function botResponseGandalf({ room }) {
   chatHelpers.send(

--- a/botResponses/botResponses.js
+++ b/botResponses/botResponses.js
@@ -8,14 +8,6 @@ var helpers = require('../helpers/helpers.js')
 var chatHelpers = require('../helpers/chatHelpers.js')
 var { respondWithGif } = require('./giphy')
 
-// function botResponseUseLinux({ room }) {
-//   chatHelpers.send(
-//     `[Why you shouldn't use Windows for TOP.](https://medium.com/@codyloyd/why-cant-i-use-windows-for-the-odin-project-bf20a4bb135f#.29b6s6fp5)
-//      - [If you need to, check out Windows Subsystem for Linux](http://wsl-guide.org/)`,
-//     room
-//   )
-// }
-
 function botResponseGandalf({ room }) {
   chatHelpers.send(
     `[![](http://emojis.slackmojis.com/emojis/images/1450458362/181/gandalf.gif)](http://giphy.com/gifs/B3hcUhLX3BFHa/tile)`,


### PR DESCRIPTION
Let it go :candle: 

*Edit for the sake of records and clarification:* it's been disruptive as the regex targets links containing `/windows` and a lot of new users have windows 10 with capabilities to run the Linux Subsystem. It just doesn't need to be there any more.